### PR TITLE
improvement: support deeply-nested theme colors

### DIFF
--- a/lib/colors.ex
+++ b/lib/colors.ex
@@ -367,20 +367,20 @@ defmodule Tails.Colors do
   def all_color_classes(colors) do
     @builtin_colors
     |> Map.merge(colors)
-    |> Enum.flat_map(fn
+    |> color_classes("")
+  end
+
+  defp color_classes(colors, prefix) do
+    Enum.flat_map(colors, fn
+      {"DEFAULT", _value} ->
+        [prefix]
+
       {key, value} when is_binary(value) ->
-        [key]
+        if prefix == "", do: [key], else: [prefix <> "-" <> key]
 
       {key, value} when is_map(value) ->
-        value
-        |> Map.keys()
-        |> Enum.map(fn
-          "DEFAULT" ->
-            key
-
-          nested_key ->
-            key <> "-" <> nested_key
-        end)
+        new_prefix = if prefix == "", do: key, else: prefix <> "-" <> key
+        color_classes(value, new_prefix)
     end)
   end
 end

--- a/test/tails_test.exs
+++ b/test/tails_test.exs
@@ -1,4 +1,110 @@
 defmodule TailsTest do
   use ExUnit.Case
   doctest Tails, import: true
+
+  @doc """
+  This is a copy of the original working version of the all_color_classes function, used to check
+  that the current version produces the same result for single level of nesting colors that the
+  original version did not support deeply-nested colors typical of custom themes.
+  """
+  def original_all_color_classes(colors) do
+    Tails.Colors.builtin_colors()
+    |> Map.merge(colors)
+    |> Enum.flat_map(fn
+      {key, value} when is_binary(value) ->
+        [key]
+
+      {key, value} when is_map(value) ->
+        value
+        |> Map.keys()
+        |> Enum.map(fn
+          "DEFAULT" ->
+            key
+
+          nested_key when is_binary(nested_key) ->
+            key <> "-" <> nested_key
+        end)
+    end)
+  end
+
+  @single_nested_colors %{
+    "black" => "#000",
+    "theme" => %{"DEFAULT" => "#eee", "500" => "#888888"}
+  }
+
+  @deeply_nested_colors %{
+    "theme" => %{
+      "fine" => %{"color_a" => "#AAAAAA", "color_b" => "#BBBBBB"},
+      "vibrant" => %{
+        "DEFAULT" => "#111111",
+        "color_c" => "#CCCCCC",
+        "color_d" => %{"light" => "#AAAAAA", "dark" => "#222222"}
+      }
+    }
+  }
+
+  describe "Tails.Colors.all_color_classes" do
+    test "returns theme color classes from single-nested colors" do
+      classes = Tails.Colors.all_color_classes(@single_nested_colors)
+      assert "theme-500" in classes
+    end
+
+    test "returns defaults for theme color classes from single-nested colors" do
+      classes = Tails.Colors.all_color_classes(@single_nested_colors)
+      assert "theme" in classes
+    end
+
+    test "returns deeply-nested theme colors" do
+      classes = Tails.Colors.all_color_classes(@deeply_nested_colors)
+
+      assert "theme-fine-color_a" in classes
+      assert "theme-fine-color_b" in classes
+      assert "theme-vibrant-color_c" in classes
+      assert "theme-vibrant-color_d-light" in classes
+      assert "theme-vibrant-color_d-dark" in classes
+    end
+
+    test "returns defaults for deeply-nested colors" do
+      classes = Tails.Colors.all_color_classes(@deeply_nested_colors)
+
+      assert "theme-vibrant" in classes
+    end
+
+    test "does not return classes without default from deeply-nested theme colors" do
+      classes = Tails.Colors.all_color_classes(@deeply_nested_colors)
+
+      refute "theme-fine" in classes
+      refute "theme-vibrant-color_d" in classes
+    end
+
+    test "returns the same result as the original implementation for single-nested theme colors" do
+      all_colors_orig = original_all_color_classes(@single_nested_colors)
+
+      all_colors_current = Tails.Colors.all_color_classes(@single_nested_colors)
+
+      assert all_colors_orig == all_colors_current
+    end
+
+    test "returns a different result from the original implementation for deeply-nested theme colors" do
+      all_colors_orig = original_all_color_classes(@deeply_nested_colors)
+
+      all_colors_current = Tails.Colors.all_color_classes(@deeply_nested_colors)
+
+      refute all_colors_orig == all_colors_current
+    end
+  end
+
+  describe "original implementation" do
+    test "does not fully support deeply-nested theme colors" do
+      classes = original_all_color_classes(@deeply_nested_colors)
+
+      assert "theme-fine" in classes
+      refute "theme-fine-color_a" in classes
+      refute "theme-fine-color_b" in classes
+      refute "theme-vibrant-color_c" in classes
+      refute "theme-vibrant-color_d-light" in classes
+      refute "theme-vibrant-color_d-dark" in classes
+      refute "theme-vibrant-color_d" in classes
+    end
+  end
 end


### PR DESCRIPTION
Theme colors in tailwind can be deeply-nested, e.g. `"my_theme": {"neutral": {"gray": "#DDDDDD", ...}}`

Originally, these classes were not surfaced by Tails so it was not able to merge classes using them with other color-related classes.

`Tails.Colors.all_color_classes` can be changed to support these deeply-nested themes so that they are surfaced correctly.

# Contributor checklist

- [x] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
