### PR TITLE
docs: fix example presentation in hexdocs

### DIFF
--- a/lib/custom.ex
+++ b/lib/custom.ex
@@ -511,14 +511,18 @@ defmodule Tails.Custom do
 
       And then we merge the whole list up into one class string.
 
-      This allows for conditional class rendering, arbitrarily nested. For example:
+      This allows for conditional class rendering, arbitrarily nested.
 
-         iex> classes(["a", "b"])
-         "a b"
-         iex> classes([a: false, b: true])
-         "b"
-         iex> classes([[a: true, b: false], [c: false, d: true]])
-         "a d"
+      ## Examples
+
+          iex> classes(["a", "b"])
+          "a b"
+
+          iex> classes([a: false, b: true])
+          "b"
+
+          iex> classes([[a: true, b: false], [c: false, d: true]])
+          "a d"
       """
       def classes(nil), do: nil
 


### PR DESCRIPTION
# Previews

<details>
<summary><strong>Before</strong></summary>

![image](https://github.com/zachdaniel/tails/assets/19409687/c40c8a51-b094-4b58-98f5-e20bc2706436)


</details>

<details>
<summary><strong>After</strong></summary>

![image](https://github.com/zachdaniel/tails/assets/19409687/2e5c6006-a249-417c-acf9-d7a84cb1196c)

</details>


# Contributor checklist

- [x] Documentation changes

