### PR TITLE
fix: Missing 5 in digits

### DIFF
--- a/lib/custom.ex
+++ b/lib/custom.ex
@@ -162,7 +162,7 @@ defmodule Tails.Custom do
       @touch_actions ~w(auto none pan-x pan-left pan-right pan-y pan-up pan-down pinch-zoom manipulation)
       @user_selects ~w(none text all auto)
       @will_change ~w(auto scroll contents transform)
-      @digits ["0", "1", "2", "3", "4", "6", "7", "8", "9"]
+      @digits Enum.map(0..9, &to_string/1)
 
       @prefixed_with_values [
         will_change: %{prefix: "will-change", values: @will_change},

--- a/test/tails_test.exs
+++ b/test/tails_test.exs
@@ -131,5 +131,12 @@ defmodule TailsTest do
 
       assert num_of_consolidated_classes == 2
     end
+
+    test "common tailwind digits work" do
+      common_digits =
+        ~w(0 0.5 1 1.5 2 2.5 3 3.5 4 5 6 7 8 9 10 11 12 14 16 20 24 28 32 36 40 44 48 52 56 60 64 72 80 96)
+
+      assert Enum.map(common_digits, &Tails.classes(["p-#{&1}", "p-4"])) |> Enum.uniq() == ["p-4"]
+    end
   end
 end


### PR DESCRIPTION
Seems like `"5"` was missed in `@digits` module attr causing:

```elixir
iex(6)> Enum.map(1..96, &classes(["p-#{&1}", "p-4"])) |> Enum.uniq
["p-4", "p-4 p-5", "p-4 p-50", "p-4 p-51", "p-4 p-52", "p-4 p-53", "p-4 p-54",
 "p-4 p-55", "p-4 p-56", "p-4 p-57", "p-4 p-58", "p-4 p-59"]
iex(7)> classes(["p-6", "p-4"])
"p-4"
```

There's also a matter of `px` not working which I left out in this PR:

```elixir
iex(4)> classes(["p-px", "p-4"])
"p-4 p-px"
```