### PR TITLE
Fix spacing for naked rounded class

### DIFF
--- a/lib/custom.ex
+++ b/lib/custom.ex
@@ -641,6 +641,8 @@ defmodule Tails.Custom do
           "rounded"
           iex> merge("rounded", "rounded-lg") |> to_string()
           "rounded-lg"
+          iex> merge("rounded", "px-2") |> to_string()
+          "px-2 rounded"
           iex> merge("border-separate", "border-spacing-1") |> to_string()
           "border-spacing-1 border-separate"
           iex> merge("shadow", "shadow-md") |> to_string()

--- a/lib/custom.ex
+++ b/lib/custom.ex
@@ -1488,7 +1488,7 @@ defmodule Tails.Custom do
       defp direction(nil, _, _, _, _), do: ""
 
       defp direction("", suffix, prefix, nil, dash_suffix?),
-        do: [prefix, dash_suffix(suffix, dash_suffix?)]
+        do: [" ", prefix, dash_suffix(suffix, dash_suffix?)]
 
       defp direction("-" <> value, suffix, prefix, nil, dash_suffix?),
         do: [" -", prefix, dash_suffix(suffix, dash_suffix?), "-", value]


### PR DESCRIPTION
The naked (no-suffix) version of the `rounded` class results in a missing leading space which causes it to meld to any preceding classes.

The first commit adds a breaking test to illustrate the bug and the second commit fixes the bug.

The doctest of `merge("rounded", "px-2") |> to_string()` in current main evaluates to `"px-2rounded"` with no space.
